### PR TITLE
cl-test-more renamed to prove

### DIFF
--- a/cl-reexport-test.asd
+++ b/cl-reexport-test.asd
@@ -12,7 +12,7 @@
   :author "Masayuki Takagi"
   :license "LLGPL"
   :depends-on (:cl-reexport
-               :cl-test-more)
+               :prove)
   :components ((:module "t"
                 :components
                 ((:file "cl-reexport"))))

--- a/t/cl-reexport.lisp
+++ b/t/cl-reexport.lisp
@@ -7,7 +7,7 @@
 (defpackage cl-reexport-test
   (:use :cl
         :cl-reexport
-        :cl-test-more))
+        :prove))
 (in-package :cl-reexport-test)
 
 


### PR DESCRIPTION
Upstream testing framework changed it's name.

https://github.com/takagi/cl-reexport/issues/3